### PR TITLE
Update init.pp

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -12,7 +12,7 @@ class solr (
   String $java_mem,
   Boolean $cloud,
   Boolean $upgrade,
-  String $zk_ensemble,
+  Optional[String] $zk_ensemble,
   String $zk_chroot,
   Integer $zk_timeout,
   String $solr_host,


### PR DESCRIPTION
zk_ensemble is optional for non-zookeeper/cloud installs. without this, puppet throws:
parameter 'zk_ensemble' expects a String value, got Undef