### PR TITLE
change zk_chroot to optional

### DIFF
--- a/data/common.yaml
+++ b/data/common.yaml
@@ -40,6 +40,6 @@ solr::staging_dir: '/opt/staging'
 solr::upgrade: false
 solr::var_dir: '/var/solr'
 solr::version: '8.2.0'
-solr::zk_chroot: 'solrcloud'
+solr::zk_chroot: ~
 solr::zk_ensemble: ~
 solr::zk_timeout: 15000

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -13,7 +13,7 @@ class solr (
   Boolean $cloud,
   Boolean $upgrade,
   Optional[String] $zk_ensemble,
-  String $zk_chroot,
+  Optional[String] $zk_chroot,
   Integer $zk_timeout,
   String $solr_host,
   String $solr_time,

--- a/templates/solr.in.sh.epp
+++ b/templates/solr.in.sh.epp
@@ -41,7 +41,11 @@ GC_TUNE="<%= $solr::gc_tune.join(' ') %>"
 # e.g. host1:2181,host2:2181/chroot
 # Leave empty if not using SolrCloud
 <% if $solr::zk_ensemble {-%>
+<% if $solr::zk_chroot {-%>
 ZK_HOST="<%= $solr::zk_ensemble %>/<%= $solr::zk_chroot %>"
+<% } else {-%>
+ZK_HOST="<%= $solr::zk_ensemble %>"
+<% } -%>
 <% } else {-%>
 #ZK_HOST=""
 <% } -%>


### PR DESCRIPTION
This change will allow for solrcloud installations using a zookeeper ensemble without a chroot
