### PR TITLE
Ensure correct systemd dependency is used

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -17,7 +17,7 @@
       "version_requirement": ">= 1.1.0 < 5.0.0"
     },
     {
-      "name": "puppet/systemd",
+      "name": "camptocamp/systemd",
       "version_requirement": ">= 2.6.0 < 3.0.0"
     }
   ],


### PR DESCRIPTION
@fraenki since the systemd module is being maintained by [camptocamp](https://forge.puppet.com/camptocamp/systemd) we have to update the dependency to avoid throwing errors / warnings during module installation / uprades through `puppet module [...]` due to the non existing `puppet-systemd` module.