### PR TITLE
Suppress warning about exceeding the soft limit for number of files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+- Suppress warning about soft limit for number of files in /opt/staging exceeded ([#5])
+
 ## [3.0.0] - 2022-08-17
 
 ### Added

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -8,8 +8,11 @@ class solr::install {
   include 'archive'
 
   file { $solr::staging_dir:
-    ensure  => directory,
-    recurse => true,
+    ensure    => directory,
+    recurse   => true,
+    # Suppress "Warning: The directory '$solr::staging_dir' contains #### entries, which exceeds the default soft limit 1000"
+    # The unpacked Solr archive has more than 1000 files, and would otherwise trigger this warning every puppet run.
+    max_files => -1,
   }
 
   archive { "${solr::staging_dir}/solr-${solr::version}.tgz":


### PR DESCRIPTION
Observed in the puppet client log without this change:

  The directory '/opt/staging' contains 2091 entries, which exceeds the
  default soft limit 1000 and may cause excessive resource consumption and
  degraded performance. To remove this warning set a value for `max_files`
  parameter or consider using an alternate method to manage large directory
  trees

This fixes #5.