### PR TITLE
Add ZK_CREATE_CHROOT to env for automatic creation of a not-yet-existing chroot path in a Cloud environment

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -78,6 +78,7 @@ The following parameters are available in the `solr` class:
 * [`var_dir`](#-solr--var_dir)
 * [`version`](#-solr--version)
 * [`zk_chroot`](#-solr--zk_chroot)
+* [`zk_create_chroot`](#-solr--zk_create_chroot)
 * [`zk_ensemble`](#-solr--zk_ensemble)
 * [`zk_timeout`](#-solr--zk_timeout)
 
@@ -359,6 +360,12 @@ Sets the version of Solr that should be installed or the target version for an u
 Data type: `Optional[String]`
 
 Sets the ZooKeeper chroot path when using Solr Cloud (see `$cloud`).
+
+##### <a name="-solr--zk_create_chroot"></a>`zk_create_chroot`
+
+Data type: `Boolean`
+
+Whether to create the ZooKeeper chroot path if it does not exist when using Solr Cloud (see `$cloud`).
 
 ##### <a name="-solr--zk_ensemble"></a>`zk_ensemble`
 

--- a/data/common.yaml
+++ b/data/common.yaml
@@ -4,48 +4,49 @@ solr::allow_paths: []
 solr::cloud: false
 solr::custom_plugins: []
 solr::custom_plugins_dir: "%{lookup('solr::var_dir')}/libs"
-solr::custom_plugins_id: 'solr.custom_plugins.dir'
+solr::custom_plugins_id: "solr.custom_plugins.dir"
 solr::enable_prometheus_exporter: false
 solr::enable_remote_jmx: false
 solr::enable_security_manager: true
 solr::enable_syslog: false
-solr::extract_dir: '/opt'
+solr::extract_dir: "/opt"
 solr::gc_log_opts:
-  - '-verbose:gc'
-  - '-Xlog:gc'
+  - "-verbose:gc"
+  - "-Xlog:gc"
 solr::gc_tune: []
 solr::java_home: ~
-solr::java_mem: '-Xms512m -Xmx512m'
+solr::java_mem: "-Xms512m -Xmx512m"
 solr::jetty_host: ~
 solr::limit_file_max: 65000
 solr::limit_proc_max: 65000
-solr::log_dir: '/var/log/solr'
+solr::log_dir: "/var/log/solr"
 solr::manage_additional_packages: true
 solr::manage_allow_paths: false
 solr::manage_custom_plugins: false
 solr::manage_service_limits: true
-solr::mirror: 'https://dlcdn.apache.org/solr/solr'
+solr::mirror: "https://dlcdn.apache.org/solr/solr"
 solr::prometheus_exporter_env_vars: {}
 solr::prometheus_exporter_extra_options: ~
 solr::prometheus_exporter_user: "%{lookup('solr::solr_user')}"
-solr::prometheus_exporter_service_name: 'solr-exporter'
-solr::service_name: 'solr'
+solr::prometheus_exporter_service_name: "solr-exporter"
+solr::service_name: "solr"
 solr::solr_base: "%{lookup('solr::extract_dir')}/%{lookup('solr::service_name')}"
 solr::solr_home: "%{lookup('solr::var_dir')}/data"
 solr::solr_host: "%{facts.networking.fqdn}"
 solr::solr_opts: []
 solr::solr_port: 8983
-solr::solr_time: 'UTC'
-solr::solr_user: 'solr'
-solr::syslog_host: 'localhost'
+solr::solr_time: "UTC"
+solr::solr_user: "solr"
+solr::syslog_host: "localhost"
 solr::syslog_port: 514
-solr::syslog_protocol: 'UDP'
-solr::syslog_app_name: 'solr'
-solr::syslog_facility: 'LOCAL0'
-solr::staging_dir: '/opt/staging'
+solr::syslog_protocol: "UDP"
+solr::syslog_app_name: "solr"
+solr::syslog_facility: "LOCAL0"
+solr::staging_dir: "/opt/staging"
 solr::upgrade: false
-solr::var_dir: '/var/solr'
+solr::var_dir: "/var/solr"
 solr::version: ~
 solr::zk_chroot: ~
+solr::zk_create_chroot: true
 solr::zk_ensemble: ~
 solr::zk_timeout: 15000

--- a/data/common.yaml
+++ b/data/common.yaml
@@ -4,47 +4,47 @@ solr::allow_paths: []
 solr::cloud: false
 solr::custom_plugins: []
 solr::custom_plugins_dir: "%{lookup('solr::var_dir')}/libs"
-solr::custom_plugins_id: "solr.custom_plugins.dir"
+solr::custom_plugins_id: 'solr.custom_plugins.dir'
 solr::enable_prometheus_exporter: false
 solr::enable_remote_jmx: false
 solr::enable_security_manager: true
 solr::enable_syslog: false
-solr::extract_dir: "/opt"
+solr::extract_dir: '/opt'
 solr::gc_log_opts:
-  - "-verbose:gc"
-  - "-Xlog:gc"
+  - '-verbose:gc'
+  - '-Xlog:gc'
 solr::gc_tune: []
 solr::java_home: ~
-solr::java_mem: "-Xms512m -Xmx512m"
+solr::java_mem: '-Xms512m -Xmx512m'
 solr::jetty_host: ~
 solr::limit_file_max: 65000
 solr::limit_proc_max: 65000
-solr::log_dir: "/var/log/solr"
+solr::log_dir: '/var/log/solr'
 solr::manage_additional_packages: true
 solr::manage_allow_paths: false
 solr::manage_custom_plugins: false
 solr::manage_service_limits: true
-solr::mirror: "https://dlcdn.apache.org/solr/solr"
+solr::mirror: 'https://dlcdn.apache.org/solr/solr'
 solr::prometheus_exporter_env_vars: {}
 solr::prometheus_exporter_extra_options: ~
 solr::prometheus_exporter_user: "%{lookup('solr::solr_user')}"
-solr::prometheus_exporter_service_name: "solr-exporter"
-solr::service_name: "solr"
+solr::prometheus_exporter_service_name: 'solr-exporter'
+solr::service_name: 'solr'
 solr::solr_base: "%{lookup('solr::extract_dir')}/%{lookup('solr::service_name')}"
 solr::solr_home: "%{lookup('solr::var_dir')}/data"
 solr::solr_host: "%{facts.networking.fqdn}"
 solr::solr_opts: []
 solr::solr_port: 8983
-solr::solr_time: "UTC"
-solr::solr_user: "solr"
-solr::syslog_host: "localhost"
+solr::solr_time: 'UTC'
+solr::solr_user: 'solr'
+solr::syslog_host: 'localhost'
 solr::syslog_port: 514
-solr::syslog_protocol: "UDP"
-solr::syslog_app_name: "solr"
-solr::syslog_facility: "LOCAL0"
-solr::staging_dir: "/opt/staging"
+solr::syslog_protocol: 'UDP'
+solr::syslog_app_name: 'solr'
+solr::syslog_facility: 'LOCAL0'
+solr::staging_dir: '/opt/staging'
 solr::upgrade: false
-solr::var_dir: "/var/solr"
+solr::var_dir: '/var/solr'
 solr::version: ~
 solr::zk_chroot: ~
 solr::zk_create_chroot: true

--- a/data/common.yaml
+++ b/data/common.yaml
@@ -24,7 +24,7 @@ solr::manage_additional_packages: true
 solr::manage_allow_paths: false
 solr::manage_custom_plugins: false
 solr::manage_service_limits: true
-solr::mirror: 'https://dlcdn.apache.org/solr/solr'
+solr::mirror: 'https://archive.apache.org/dist/solr/solr'
 solr::prometheus_exporter_env_vars: {}
 solr::prometheus_exporter_extra_options: ~
 solr::prometheus_exporter_user: "%{lookup('solr::solr_user')}"

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -142,6 +142,9 @@
 # @param zk_chroot
 #   Sets the ZooKeeper chroot path when using Solr Cloud (see `$cloud`).
 #
+# @param zk_create_chroot
+#   Whether to create the ZooKeeper chroot path if it does not exist when using Solr Cloud (see `$cloud`).
+#
 # @param zk_ensemble
 #   Sets the host:port information for every machine that is part of the ZooKeeper ensemble when using Solr Cloud (see `$cloud`).
 #
@@ -168,6 +171,7 @@ class solr (
   Boolean $upgrade,
   Optional[String] $zk_ensemble,
   Optional[String] $zk_chroot,
+  Boolean $zk_create_chroot,
   Integer $zk_timeout,
   String $solr_host,
   String $solr_time,

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -9,13 +9,13 @@ class solr::service {
   if ($solr::manage_service_limits) {
     if ($facts['kernel'] == 'Linux') {
       # Configure systemd service limits.
-      systemd::service_limits { "${solr::service_name}.service":
-        limits          => {
+      systemd::manage_dropin { "${solr::service_name}_limits.conf":
+        unit          => "${solr::service_name}.service",
+        service_entry => {
           'LimitNOFILE' => $solr::limit_file_max,
           'LimitNPROC'  => $solr::limit_proc_max,
           'TasksMax'    => $solr::limit_proc_max,
         },
-        restart_service => false,
       }
 
       # Additionally set limits for the Solr user.

--- a/spec/classes/solr_spec.rb
+++ b/spec/classes/solr_spec.rb
@@ -104,7 +104,7 @@ describe 'solr' do
             ).with_content(%r{SOLR_ENV="/var/solr/solr.in.sh"})
           }
 
-          it { is_expected.to contain_systemd__service_limits('solr.service') }
+          it { is_expected.to contain_systemd__manage_dropin('solr_limits.conf') }
           it { is_expected.to contain_limits__limits('solr/nofile') }
           it { is_expected.to contain_limits__limits('solr/nproc') }
 
@@ -121,7 +121,7 @@ describe 'solr' do
 
           it { is_expected.to compile.with_all_deps }
 
-          it { is_expected.not_to contain_systemd__service_limits('solr.service') }
+          it { is_expected.not_to contain_systemd__manage_dropin('solr_limits.conf') }
           it { is_expected.not_to contain_limits__limits('solr/nofile') }
           it { is_expected.not_to contain_limits__limits('solr/nproc') }
         end

--- a/spec/classes/solr_spec.rb
+++ b/spec/classes/solr_spec.rb
@@ -290,6 +290,20 @@ describe 'solr' do
 
           it { is_expected.to contain_file('/var/solr/solr.in.sh').with_content(%r{SOLR_SECURITY_MANAGER_ENABLED=true}) }
         end
+
+        context 'solr class when zk_create_chroot is true' do
+          let(:params) do
+            {
+              version: '9.4.1',
+              zk_ensemble: 'zk1:2181,zk2:2181,zk3:2181',
+              zk_chroot: 'solr',
+              zk_create_chroot: true,
+            }
+          end
+
+          it { is_expected.to contain_file('/var/solr/solr.in.sh').with_content(%r{ZK_CREATE_CHROOT=true}) }
+          it { is_expected.to contain_file('/var/solr/solr.in.sh').with_content(%r{ZK_HOST="zk1:2181,zk2:2181,zk3:2181/solr"}) }
+        end
       end
     end
   end

--- a/templates/solr.in.sh.epp
+++ b/templates/solr.in.sh.epp
@@ -42,6 +42,7 @@ GC_TUNE="<%= $solr::gc_tune.join(' ') %>"
 # Leave empty if not using SolrCloud
 <% if $solr::zk_ensemble {-%>
 <% if $solr::zk_chroot {-%>
+ZK_CREATE_CHROOT=<%= $solr::zk_create_chroot %>
 ZK_HOST="<%= $solr::zk_ensemble %>/<%= $solr::zk_chroot %>"
 <% } else {-%>
 ZK_HOST="<%= $solr::zk_ensemble %>"


### PR DESCRIPTION
Hey there, just added in the ability to set this env variable (and defaulted to `true` as I don't see auto creation of the chroot you explicitly set as a potential negative).

From https://solr.apache.org/guide/solr/latest/deployment-guide/solr-control-script-reference.html:
> Set the `ZK_CREATE_CHROOT` environment variable to true if your ZK host has a chroot path, and you want to create it automatically.



(thank you for not using params.pp)